### PR TITLE
Integration of the new ton-compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "dist/**/*",
     "bin/**/*"
   ],
+  "jest":{
+    "testTimeout": 15000
+  },
   "devDependencies": {
     "@babel/core": "^7.16.0",
     "@babel/preset-env": "^7.16.4",
@@ -17,14 +20,17 @@
     "@types/bn.js": "^5.1.0",
     "@types/jest": "^27.0.3",
     "@types/node": "^16.11.10",
+    "@types/tmp": "^0.2.3",
     "copyfiles": "^2.4.1",
     "jest": "^27.3.1",
+    "ton": "^12.1.5",
     "ts-node": "^10.7.0",
     "typescript": "^4.5.2"
   },
   "dependencies": {
     "bn.js": "^5.2.0",
-    "ton-compiler": "^0.9.0"
+    "tmp": "^0.2.1",
+    "ton-compiler": "^2.0.0"
   },
   "peerDependencies": {
     "ton": ">=11.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ton-contract-executor",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "TON Contracts local executor",
   "main": "dist/index.js",
   "repository": "http://github.com/Naltox/ton-contract-executor/",

--- a/src/smartContract/SmartContract.spec.ts
+++ b/src/smartContract/SmartContract.spec.ts
@@ -111,7 +111,7 @@ describe('SmartContract', () => {
         let dataCell = new Cell()
         dataCell.bits.writeUint(0, 32)
 
-        let contract = await SmartContract.fromFuncSource(source, dataCell, {getMethodsMutate: true})
+        let contract = await SmartContract.fromFuncSource(source, dataCell, true, {getMethodsMutate: true})
 
         let res = await contract.invokeGetMethod('test', [])
         expect(res.result[0]).toEqual(new BN(0))
@@ -296,5 +296,27 @@ describe('SmartContract', () => {
         let contract = await SmartContract.fromFuncSource(source, new Cell())
         let res = await contract.invokeGetMethod('test', [])
         expect(res.exit_code).toEqual(777)
+    })
+    
+    it('should run multiple sources', async () => {
+        const source1 = `
+            int double_the_num(int n) {
+                return n * 2;
+            }
+        `;
+        const source2 = `
+            () main() {
+                ;; noop
+            }
+
+            int test() method_id {
+                return double_the_num(777);
+            }
+        `
+        let contract = await SmartContract.fromFuncSources([source1, source2], new Cell())
+        let res = await contract.invokeGetMethod('test', [])
+
+        expect(res.result[0]).toBeInstanceOf(BN)
+        expect(res.result[0]).toEqual(new BN(777 * 2))
     })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -73,7 +73,7 @@
     "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
 
     /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
+    "strict": false,                                      /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied `any` type.. */
     // "strictNullChecks": true,                         /* When type checking, take into account `null` and `undefined`. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -1117,6 +1117,11 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
+"@scarf/scarf@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@scarf/scarf/-/scarf-1.1.1.tgz#d8b9f20037b3a37dbf8dcdc4b3b72f9285bfce35"
+  integrity sha512-VGbKDbk1RFIaSmdVb0cNjjWJoRWRI/Weo23AjRCC2nryO0iAS8pzsToJfPVPtVs74WHw4L1UTADNdIYRLkirZQ==
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
@@ -1244,6 +1249,11 @@
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
+
+"@types/tmp@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.3.tgz#908bfb113419fd6a42273674c00994d40902c165"
+  integrity sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==
 
 "@types/yargs-parser@*":
   version "20.2.1"
@@ -1470,7 +1480,7 @@ balanced-match@^1.0.0:
 bn.js@4.11.6:
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.6.tgz#53344adb14617a13f6e8dd2ce28905d1c0ba3215"
-  integrity sha1-UzRK2xRhehP26N0s4okF0cC6MhU=
+  integrity sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==
 
 bn.js@5.2.0, bn.js@^5.2.0:
   version "5.2.0"
@@ -1709,9 +1719,9 @@ data-urls@^2.0.0:
     whatwg-url "^8.0.0"
 
 dataloader@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.0.0.tgz#41eaf123db115987e21ca93c005cd7753c55fe6f"
-  integrity sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.1.0.tgz#c69c538235e85e7ac6c6c444bae8ecabf5de9df7"
+  integrity sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ==
 
 debug@4, debug@^4.1.0, debug@^4.1.1:
   version "4.3.3"
@@ -1834,7 +1844,7 @@ esutils@^2.0.2:
 ethjs-unit@0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/ethjs-unit/-/ethjs-unit-0.1.6.tgz#c665921e476e87bce2a9d588a6fe0405b2c41699"
-  integrity sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=
+  integrity sha512-/Sn9Y0oKl0uqQuvgFk/zQgR7aw1g36qX/jzSQ5lSwlO0GigPymk4eGQfeNTD03w1dPOqfz8V77Cy43jH56pagw==
   dependencies:
     bn.js "4.11.6"
     number-to-bn "1.7.0"
@@ -1904,9 +1914,9 @@ find-up@^4.0.0, find-up@^4.1.0:
     path-exists "^4.0.0"
 
 follow-redirects@^1.14.7:
-  version "1.14.7"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
-  integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
 form-data@^3.0.0:
   version "3.0.1"
@@ -1918,9 +1928,9 @@ form-data@^3.0.0:
     mime-types "^2.1.12"
 
 fp-ts@^2.11.1:
-  version "2.11.5"
-  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.11.5.tgz#97cceb26655b1452d7088d6fb0864f84cceffbe4"
-  integrity sha512-OqlwJq1BdpB83BZXTqI+dNcA6uYk6qk4u9Cgnt64Y+XS7dwdbp/mobx8S2KXf2AXH+scNmA/UVK3SEFHR3vHZA==
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.13.1.tgz#1bf2b24136cca154846af16752dc29e8fa506f2a"
+  integrity sha512-0eu5ULPS2c/jsa1lGFneEFFEdTbembJv8e4QKXeVJ3lm/5hyve06dlKZrpxmMwJt6rYen7sxmHHK2CLaXvWuWQ==
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2078,14 +2088,16 @@ inherits@2, inherits@^2.0.1, inherits@~2.0.1, inherits@~2.0.3:
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 io-ts-reporters@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/io-ts-reporters/-/io-ts-reporters-2.0.0.tgz#a7ae071b69a170c4d475d15bb93bfc964da6b04b"
-  integrity sha512-lcCD/Q77jcWjq7jBQb8nLfCU4DM/9hiQakYHNT1FLCA6kwMuHe0QEcugh27vrT3S5FoQDiWXq3ofaYR7GWAcOg==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/io-ts-reporters/-/io-ts-reporters-2.0.1.tgz#0154545aefd115f0f175a41743ed7327d19b1c34"
+  integrity sha512-RVpLstYBsmTGgCW9wJ5KVyN/eRnRUDp87Flt4D1O3aJ7oAnd8csq8aXuu7ZeNK8qEDKmjUl9oUuzfwikaNAMKQ==
+  dependencies:
+    "@scarf/scarf" "^1.1.1"
 
 io-ts@^2.2.16:
-  version "2.2.16"
-  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.2.16.tgz#597dffa03db1913fc318c9c6df6931cb4ed808b2"
-  integrity sha512-y5TTSa6VP6le0hhmIyN0dqEXkrZeJLeC5KApJq6VLci3UEKF80lZ+KuoUs02RhBxNWlrqSNxzfI7otLX1Euv8Q==
+  version "2.2.19"
+  resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.2.19.tgz#4ba5e120472a0a07ff693fdb3d7075ea1c1b77c3"
+  integrity sha512-ED0GQwvKRr5C2jqOOJCkuJW2clnbzqFexQ8V7Qsb+VB36S1Mk/OKH7k0FjSe4mjKy9qBRA3OqgVGyFMUEKIubw==
 
 is-core-module@^2.2.0:
   version "2.8.0"
@@ -2107,7 +2119,7 @@ is-generator-fn@^2.0.0:
 is-hex-prefixed@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz#7d8d37e6ad77e5d127148913c573e082d777f554"
-  integrity sha1-fY035q135dEnFIkTxXPggtd39VQ=
+  integrity sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==
 
 is-number@^7.0.0:
   version "7.0.0"
@@ -2837,7 +2849,7 @@ npm-run-path@^4.0.1:
 number-to-bn@1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/number-to-bn/-/number-to-bn-1.7.0.tgz#bb3623592f7e5f9e0030b1977bd41a0c53fe1ea0"
-  integrity sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=
+  integrity sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==
   dependencies:
     bn.js "4.11.6"
     strip-hex-prefix "1.0.0"
@@ -3252,7 +3264,7 @@ strip-final-newline@^2.0.0:
 strip-hex-prefix@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz#0c5f155fef1151373377de9dbb588da05500e36f"
-  integrity sha1-DF8VX+8RUTczd96du1iNoFUA428=
+  integrity sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==
   dependencies:
     is-hex-prefixed "1.0.0"
 
@@ -3304,9 +3316,9 @@ terminal-link@^2.0.0:
     supports-hyperlinks "^2.0.0"
 
 teslabot@^1.3.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/teslabot/-/teslabot-1.4.1.tgz#9469263c87161cdcc1cf691d1b63542c2d9e8e00"
-  integrity sha512-/MFWq3nb4tocXHVkWnkGLkeYKbRyhgtXKuzpZBgSkLqSVphfzal86ixNs3yc6VTbfRjwap56qG5YCW5B85BcZw==
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/teslabot/-/teslabot-1.5.0.tgz#70f544516699ca5f696d8ae94f3d12cd495d5cd6"
+  integrity sha512-e2MmELhCgrgZEGo7PQu/6bmYG36IDH+YrBI1iGm6jovXkeDIGa3pZ2WSqRjzkuw2vt1EqfkZoV5GpXgqL8QJVg==
 
 test-exclude@^6.0.0:
   version "6.0.0"
@@ -3354,10 +3366,10 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-ton-compiler@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/ton-compiler/-/ton-compiler-0.9.0.tgz#c8a3421b65122332c7f6372ddd39848614f2a670"
-  integrity sha512-7ZyjmSSmI8s/hd+H3c8qCzvUxDWLml4T8Lhr3DNAucadWhAXiVniTgPHHQNt5nbfZMvHKGevGw18pRkf5cFBZA==
+ton-compiler@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ton-compiler/-/ton-compiler-2.0.0.tgz#1a972e32aa06967fc9d6744f637376792ef64b3a"
+  integrity sha512-ZLljfTeneFPd3ENfxx/OHhwKZzQF8j8oShVjqS5LQC7O603xmzU6QD8XGe/syqIZJx2a5xvho1So0nqrbqXWQw==
   dependencies:
     arg "^5.0.1"
     tmp "^0.2.1"
@@ -3378,10 +3390,10 @@ ton-crypto@2.1.0:
     ton-crypto-primitives "2.0.0"
     tweetnacl "1.0.3"
 
-ton@^11.0.1:
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/ton/-/ton-11.0.1.tgz#776ebb7c6405d84b4cb4bdde1da48f8c186c75df"
-  integrity sha512-tUn01NcdbbMW3f6sEY3ZYJ8pdxxv0UN3TBumPS7vPooE/6CPCTQEZtHrWaz76SAO6YKwAYeG2g6fBFg7SGEgAg==
+ton@^12.1.5:
+  version "12.1.5"
+  resolved "https://registry.yarnpkg.com/ton/-/ton-12.1.5.tgz#8d4d1857ce1887af565d9b657b05dca361db27d3"
+  integrity sha512-wuk/HSiaVHocTY/r0oZUF7+RgBqQANu4MHGr9Wm2+7EqoseBFKRsDxk0vcSJwHN2oqKgn46bCQ3DhC/LRPwrJA==
   dependencies:
     axios "^0.25.0"
     bn.js "5.2.0"


### PR DESCRIPTION
The new `ton-compiler`(**v2.0.0**) module is based on wasm and can work on windows, Linux, and macOS easily. ton-contract-executor was using the **0.9.0** which couldn't run on windows. This PR implements the following:

- Upgrades the used `ton-compiler` to **2.0.0** without any higher-level changes
- Add `fromFuncSources`, and `fromFuncFiles` with the capability of compiling multiple files and sources + Tests
- Increase `jest` timeout (It takes time to run some workers and it exceeds the default timeout)

Note: As the new `ton-compiler` uses direct file paths, so the workaround was using temporary files and doing cleanup afterward.